### PR TITLE
Account API Models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+notes/

--- a/src/@types/Account.ts
+++ b/src/@types/Account.ts
@@ -1,0 +1,32 @@
+/**
+ * Player Universally Unique IDentifier
+ * https://www.riotgames.com/en/DevRel/player-universally-unique-identifiers-and-a-new-security-layer
+ */
+export type PUUID = string;
+
+/**
+ * Another way to identify your account to RIOT APIs.
+ * TODO: This needs to be understood better, as of now it's purely here for completeness
+ */
+export type Authorization = string;
+
+/**
+ * Different games supported by the Accounts api
+ */
+export enum Game {
+  val = "val",
+  lor = "lor",
+}
+
+/**
+ * Identifiers for the regions an account may belong to, known as shards
+ */
+export enum Shard {
+  na = "na",
+  br = "br",
+  emea = "emea",
+  jp = "jp",
+  kr = "kr",
+  latam = "latam",
+  sea = "sea",
+}

--- a/src/models/account-v1/Account.ts
+++ b/src/models/account-v1/Account.ts
@@ -1,0 +1,21 @@
+import { PUUID } from "../../@types/Account";
+
+export class Account {
+  /**
+   * Player Universally Unique IDentifier
+   * https://www.riotgames.com/en/DevRel/player-universally-unique-identifiers-and-a-new-security-layer
+   */
+  puuid: PUUID;
+
+  /**
+   * Players game name ie. Lamirp, JC00K
+   * This field may be excluded from the response if the account doesn't have a gameName.
+   */
+  gameName?: string;
+
+  /**
+   * Players tag line (tag minus the #) #NA1 -> NA1
+   * This field may be excluded from the response if the account doesn't have a tagLine.
+   */
+  tagLine?: string;
+}

--- a/src/models/account-v1/ActiveShard.ts
+++ b/src/models/account-v1/ActiveShard.ts
@@ -1,0 +1,19 @@
+import { Game, Shard, PUUID } from "../../@types/Account";
+
+export class ActiveShard {
+  /**
+   * Player Universally Unique IDentifier
+   * https://www.riotgames.com/en/DevRel/player-universally-unique-identifiers-and-a-new-security-layer
+   */
+  puuid: PUUID;
+
+  /**
+   * Short name of the RIOT game ie. val, lor
+   */
+  game: Game;
+
+  /**
+   * Shard the account is active on, this may only be one
+   */
+  activeShard: Shard;
+}


### PR DESCRIPTION
Account API: https://developer.riotgames.com/apis#account-v1
You may notice, it's not as well documented in parts as the Valorant API. I manually tested using personal account details to make requests and evaluate the request/response models. This way I could see what the data shapes looked like myself.

1. Adds models for the Account API
2. Adds types for the Account API

Documents some specific nomenclature used in the RIOT world.